### PR TITLE
deps: Update to eslint-config-plus-prettier v4

### DIFF
--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -1,7 +1,3 @@
 {
-  "extends": "eslint-config-plus-prettier/.npmpackagejsonlintrc.json",
-  "rules": {
-    "no-caret-version-dependencies": "error",
-    "prefer-caret-version-dependencies": "off"
-  }
+  "extends": "eslint-config-plus-prettier/packagelint/server"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/supertest": "6.0.2",
         "autoprefixer": "10.4.20",
         "concurrently": "9.1.0",
-        "eslint-config-plus-prettier": "3.0.0",
+        "eslint-config-plus-prettier": "4.0.0",
         "nodemon": "3.1.7",
         "postcss": "8.4.47",
         "postcss-cli": "11.0.0",
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/eslint-config-plus-prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-plus-prettier/-/eslint-config-plus-prettier-3.0.0.tgz",
-      "integrity": "sha512-/bLvOgDVCwnL3vAP8R2YGwiStIyaYoMfIgBLEpn6A97O5u6nwTntVxG2NZnGYcIzY1RIZH0nEdBDkwtwqAHYsw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-plus-prettier/-/eslint-config-plus-prettier-4.0.0.tgz",
+      "integrity": "sha512-NtW9JP8KjG4jw21J7Sdv8WQkR3JxElrj1sIp6PQ2RUXpaT+QhVGOVHBI3AP5m8EMJDTKw48MUGzn3+YIKII9wg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/supertest": "6.0.2",
     "autoprefixer": "10.4.20",
     "concurrently": "9.1.0",
-    "eslint-config-plus-prettier": "3.0.0",
+    "eslint-config-plus-prettier": "4.0.0",
     "nodemon": "3.1.7",
     "postcss": "8.4.47",
     "postcss-cli": "11.0.0",
@@ -56,5 +56,5 @@
     "tailwindcss": "3.4.14",
     "typescript": "5.6.3"
   },
-  "prettier": "eslint-config-plus-prettier/.prettierrc.json"
+  "prettier": "eslint-config-plus-prettier/prettier"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "eslint-config-plus-prettier/tsconfig.json",
+  "extends": "eslint-config-plus-prettier/tsconfig",
   "include": ["src", "test"],
   "compilerOptions": {
     "outDir": "dist"


### PR DESCRIPTION
imports have changed, and it supports server configuration for package lint